### PR TITLE
Parse website using beautiful soup

### DIFF
--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -1,5 +1,6 @@
 import sys
 from urllib import request
+from bs4 import BeautifulSoup
 from tabulate import tabulate
 
 def usage():
@@ -20,20 +21,19 @@ def search () :
 	f = request.urlopen('https://pypi.org/search/?q=%s' % keyword)
 	raw_text=str(f.read())
 
-	raw_names=raw_text.split('<span class="package-snippet__name">')[1:-2]
-	names=[]
-	for name in raw_names :
-		names.append(name.split('</span>')[0])
+	soup = BeautifulSoup(raw_text, 'html.parser')
+ 
+	rows = [
+		['Name', 'Description'],
+		['', '']
+	]
 
+	for package in soup.find_all('a', 'package-snippet'):
+		name = package.find('span', 'package-snippet__name').text
+		description = package.find('p', 'package-snippet__description').text
+		rows.append([name, description])
 
-	raw_desc=raw_text.split('<p class="package-snippet__description">')[1:-2]
-	descs=[]
-	for desc in raw_desc :
-		descs.append(desc.split('</p>')[0])
-
-	header=[['Name', 'Description'],['','']]
-	rows=[[names[i],descs[i]] for i in range(len(names))]
-	print(tabulate(header+rows))
+	print(tabulate(rows))
 
 if __name__ == '__main__':
 	main()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     url='https://github.com/victorgarric/pip_search',
     description="A package to search like pip used to via PyPi",
     packages=setuptools.find_packages(),
-	install_requires=['tabulate'],
+	install_requires=['tabulate', 'beautifulsoup4'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
pip_search now can also handle single occurrences of a package (e.g pkbar)

I found that pip_search returns nothing when it has to handle a package which has a single occurrence like `pkbar`:

```
(gitcrawl-env) ➜  gitcrawl git:(for-github) ✗ pip_search pkbar
----  -----------
Name  Description

----  -----------
```

The changes I made now handle this case accordingly:
```
(ps-env) ➜  pip_search git:(patch-for-package-handling) ✗ pip_search pkbar
-----  ------------------------------
Name   Description

pkbar  Keras Progress Bar for PyTorch
-----  ------------------------------
```

kind regards,
 Neda 

