### PR TITLE
Feature/installed versions

### DIFF
--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -2,6 +2,7 @@ from rich.console import Console
 from rich.table import Table
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin
+from .utils import check_version
 import requests
 import re
 
@@ -27,6 +28,11 @@ def search(query: str):
         link = urljoin(api_url, snippet.get('href'))
         package = re.sub(r"\s+", " ", snippet.select_one('span[class*="name"]').text.strip())
         version = re.sub(r"\s+", " ", snippet.select_one('span[class*="version"]').text.strip())
+        checked_version = check_version(package)
+        if checked_version == version:
+            version = f"[bold green]== {version}[/]"
+        elif checked_version is not False:
+            version = f"[bold purple]{checked_version}[/] ^{version}"
         released = re.sub(r"\s+", " ", snippet.select_one('span[class*="released"]').text.strip())
         description = re.sub(r"\s+", " ", snippet.select_one('p[class*="description"]').text.strip())
         emoji = ':open_file_folder:'

--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -30,9 +30,9 @@ def search(query: str):
         version = re.sub(r"\s+", " ", snippet.select_one('span[class*="version"]').text.strip())
         checked_version = check_version(package)
         if checked_version == version:
-            version = f"[bold green]== {version}[/]"
+            version = f"[bold green]{version} ==[/]"
         elif checked_version is not False:
-            version = f"[bold purple]{checked_version}[/] ^{version}"
+            version = f"{version} > [bold purple]{checked_version}[/]"
         released = re.sub(r"\s+", " ", snippet.select_one('span[class*="released"]').text.strip())
         description = re.sub(r"\s+", " ", snippet.select_one('p[class*="description"]').text.strip())
         emoji = ':open_file_folder:'

--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -8,37 +8,60 @@ import re
 
 
 def search(query: str):
-    api_url = 'https://pypi.org/search/'
+    api_url = "https://pypi.org/search/"
     snippets = []
     s = requests.Session()
     for page in range(1, 3):
-        params = {'q': query, 'page': page}
+        params = {"q": query, "page": page}
         r = s.get(api_url, params=params)
-        soup = BeautifulSoup(r.text, 'html.parser')
+        soup = BeautifulSoup(r.text, "html.parser")
         snippets += soup.select('a[class*="snippet"]')
-        if not hasattr(s, 'start_url'):
-            s.start_url = r.url.rsplit('&page', maxsplit=1).pop(0)
+        if not hasattr(s, "start_url"):
+            s.start_url = r.url.rsplit("&page", maxsplit=1).pop(0)
 
-    table = Table(title=f'[not italic]:snake:[/] [bold][magenta]{s.start_url} [not italic]:snake:[/]')
-    table.add_column('Package', style='cyan', no_wrap=True)
-    table.add_column('Version', style='bold yellow')
-    table.add_column('Released', style='bold green')
-    table.add_column('Description', style='bold blue')
+    table = Table(
+        title=(
+            f"[not italic]:snake:[/] [bold][magenta]{s.start_url} "
+            "[not italic]:snake:[/]"
+        )
+    )
+    table.add_column("Package", style="cyan", no_wrap=True)
+    table.add_column("Version", style="bold yellow")
+    table.add_column("Released", style="bold green")
+    table.add_column("Description", style="bold blue")
     for snippet in snippets:
-        link = urljoin(api_url, snippet.get('href'))
-        package = re.sub(r"\s+", " ", snippet.select_one('span[class*="name"]').text.strip())
-        version = re.sub(r"\s+", " ", snippet.select_one('span[class*="version"]').text.strip())
+        link = urljoin(api_url, snippet.get("href"))
+        package = re.sub(
+            r"\s+", " ", snippet.select_one('span[class*="name"]').text.strip()
+        )
+        version = re.sub(
+            r"\s+",
+            " ",
+            snippet.select_one('span[class*="version"]').text.strip(),
+        )
         checked_version = check_version(package)
         if checked_version == version:
             version = f"[bold green]{version} ==[/]"
         elif checked_version is not False:
             version = f"{version} > [bold purple]{checked_version}[/]"
-        released = re.sub(r"\s+", " ", snippet.select_one('span[class*="released"]').text.strip())
-        description = re.sub(r"\s+", " ", snippet.select_one('p[class*="description"]').text.strip())
-        emoji = ':open_file_folder:'
-        table.add_row(f'[link={link}]{emoji}[/link] {package}', version, released, description)
+        released = re.sub(
+            r"\s+",
+            " ",
+            snippet.select_one('span[class*="released"]').text.strip(),
+        )
+        description = re.sub(
+            r"\s+",
+            " ",
+            snippet.select_one('p[class*="description"]').text.strip(),
+        )
+        emoji = ":open_file_folder:"
+        table.add_row(
+            f"[link={link}]{emoji}[/link] {package}",
+            version,
+            released,
+            description,
+        )
 
     console = Console()
     console.print(table)
     return
-

--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -41,7 +41,7 @@ def search(query: str):
         )
         checked_version = check_version(package)
         if checked_version == version:
-            version = f"[bold green]{version} ==[/]"
+            version = f"[bold cyan]{version} ==[/]"
         elif checked_version is not False:
             version = f"{version} > [bold purple]{checked_version}[/]"
         released = re.sub(

--- a/pip_search/utils.py
+++ b/pip_search/utils.py
@@ -1,0 +1,9 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
+
+
+def check_version(package: str) -> str | None:
+    try:
+        return pkg_version(package)
+    except PackageNotFoundError:
+        return False


### PR DESCRIPTION
Resolves issue #10

## Installed versions

- Versions of packages with the latest installed version are displayed followed by `==` and in `bold cyan`.

| Package                        | Version      | Released     | Description      |
| :------------------------------ | :----------- | :----------- | :--------------- |
| 📂 mypy-extensions             | 0.4.3 ==     | Oct 17, 2019 | Experimental type s...  |

- Versions of installed packages other than the version found in the repository will be displayed in `bold purple` after the latest version and `>`

| Package                        | Version      | Released     | Description      |
| :------------------------------ | :----------- | :----------- | :--------------- |
| 📂 mypy                        | 0.910 > 0.900 | Jun 22, 2021 | Optional static typing for Python                                                    |


- Another packages versions no installed yet are displayed in `bold yellow` color.

| Package                        | Version      | Released     | Description      |
| :------------------------------ | :----------- | :----------- | :--------------- |
| 📂 mypy-mypyc                  | 0.670        | Feb 8, 2019  | Optional static typing for Py...                           |


## Image for color demonstration
![image](https://user-images.githubusercontent.com/11961296/147135049-336cfa58-07ee-4c15-8e92-33c03b424a07.png)

