### PR TITLE
remove unin types

### DIFF
--- a/pip_search/__init__.py
+++ b/pip_search/__init__.py
@@ -1,3 +1,3 @@
 from .pip_search import *
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/pip_search/utils.py
+++ b/pip_search/utils.py
@@ -6,7 +6,7 @@ if py_ver[0] == 3 and py_ver[1] >= 8:
 	from importlib.metadata import version as pkg_version
 
 
-	def check_version(package: str) -> str | None:
+	def check_version(package: str):
 		try:
 			return pkg_version(package)
 		except PackageNotFoundError:


### PR DESCRIPTION
According to [PEP 604](https://www.python.org/dev/peps/pep-0604/), unin types has only been supported since 3.10.