### PR TITLE
Fix for PyPI change from "released" to "created"

### DIFF
--- a/pip_search/__main__.py
+++ b/pip_search/__main__.py
@@ -21,7 +21,7 @@ def main():
         type=str,
         const="name",
         nargs="?",
-        choices=["name", "version", "created"],
+        choices=["name", "version", "released"],
         help="sort results by package name, version or \
                         release date (default: %(const)s)",
     )
@@ -59,7 +59,7 @@ def main():
     )
     table.add_column("Package", style="cyan", no_wrap=True)
     table.add_column("Version", style="bold yellow")
-    table.add_column("Created", style="bold green")
+    table.add_column("Released", style="bold green")
     table.add_column("Description", style="bold blue")
     emoji = ":open_file_folder:"
     for package in result:
@@ -73,7 +73,7 @@ def main():
         table.add_row(
             f"[link={package.link}]{emoji}[/link] {package.name}",
             package.version,
-            package.created_date_str(args.date_format),
+            package.released_date_str(args.date_format),
             package.description,
         )
     console = Console()

--- a/pip_search/__main__.py
+++ b/pip_search/__main__.py
@@ -21,7 +21,7 @@ def main():
         type=str,
         const="name",
         nargs="?",
-        choices=["name", "version", "released"],
+        choices=["name", "version", "created"],
         help="sort results by package name, version or \
                         release date (default: %(const)s)",
     )
@@ -59,7 +59,7 @@ def main():
     )
     table.add_column("Package", style="cyan", no_wrap=True)
     table.add_column("Version", style="bold yellow")
-    table.add_column("Released", style="bold green")
+    table.add_column("Created", style="bold green")
     table.add_column("Description", style="bold blue")
     emoji = ":open_file_folder:"
     for package in result:
@@ -73,7 +73,7 @@ def main():
         table.add_row(
             f"[link={package.link}]{emoji}[/link] {package.name}",
             package.version,
-            package.released_date_str(args.date_format),
+            package.created_date_str(args.date_format),
             package.description,
         )
     console = Console()

--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -28,24 +28,24 @@ class Package:
 
     name: str
     version: str
-    released: str
+    created: str
     description: str
     link: InitVar[str] = None
 
     def __post_init__(self, link: str = None):
         self.link = link or config.link_defualt_format.format(package=self)
-        self.released_date = datetime.strptime(
-            self.released, "%Y-%m-%dT%H:%M:%S%z"
+        self.created_date = datetime.strptime(
+            self.created, "%Y-%m-%dT%H:%M:%S%z"
         )
 
-    def released_date_str(self, date_format: str = config.date_format) -> str:
-        """Return the released date as a string formatted
+    def created_date_str(self, date_format: str = config.date_format) -> str:
+        """Return the created date as a string formatted
         according to date_formate ou Config.date_format (default)
 
         Returns:
             str: Formatted date string
         """
-        return self.released_date.strftime(date_format)
+        return self.created_date.strftime(date_format)
 
 
 def search(
@@ -79,10 +79,10 @@ def search(
                     s.select_one('span[class*="version"]').text.strip()
                 ),
             )
-        elif opts.sort == "released":
+        elif opts.sort == "created":
             snippets = sorted(
                 snippets,
-                key=lambda s: s.select_one('span[class*="released"]').find(
+                key=lambda s: s.select_one('span[class*="created"]').find(
                     "time"
                 )["datetime"],
             )
@@ -97,10 +97,10 @@ def search(
             " ",
             snippet.select_one('span[class*="version"]').text.strip(),
         )
-        released = re.sub(
+        created = re.sub(
             r"\s+",
             " ",
-            snippet.select_one('span[class*="released"]').find("time")[
+            snippet.select_one('span[class*="created"]').find("time")[
                 "datetime"
             ],
         )
@@ -109,4 +109,4 @@ def search(
             " ",
             snippet.select_one('p[class*="description"]').text.strip(),
         )
-        yield Package(package, version, released, description, link)
+        yield Package(package, version, created, description, link)

--- a/pip_search/pip_search.py
+++ b/pip_search/pip_search.py
@@ -28,24 +28,24 @@ class Package:
 
     name: str
     version: str
-    created: str
+    released: str
     description: str
     link: InitVar[str] = None
 
     def __post_init__(self, link: str = None):
         self.link = link or config.link_defualt_format.format(package=self)
-        self.created_date = datetime.strptime(
-            self.created, "%Y-%m-%dT%H:%M:%S%z"
+        self.released_date = datetime.strptime(
+            self.released, "%Y-%m-%dT%H:%M:%S%z"
         )
 
-    def created_date_str(self, date_format: str = config.date_format) -> str:
-        """Return the created date as a string formatted
+    def released_date_str(self, date_format: str = config.date_format) -> str:
+        """Return the released date as a string formatted
         according to date_formate ou Config.date_format (default)
 
         Returns:
             str: Formatted date string
         """
-        return self.created_date.strftime(date_format)
+        return self.released_date.strftime(date_format)
 
 
 def search(
@@ -79,7 +79,7 @@ def search(
                     s.select_one('span[class*="version"]').text.strip()
                 ),
             )
-        elif opts.sort == "created":
+        elif opts.sort == "released":
             snippets = sorted(
                 snippets,
                 key=lambda s: s.select_one('span[class*="created"]').find(
@@ -97,7 +97,7 @@ def search(
             " ",
             snippet.select_one('span[class*="version"]').text.strip(),
         )
-        created = re.sub(
+        released = re.sub(
             r"\s+",
             " ",
             snippet.select_one('span[class*="created"]').find("time")[
@@ -109,4 +109,4 @@ def search(
             " ",
             snippet.select_one('p[class*="description"]').text.strip(),
         )
-        yield Package(package, version, created, description, link)
+        yield Package(package, version, released, description, link)


### PR DESCRIPTION
PyPI now uses class `package-snippet__created` for the date on a package. The broke `pip-search` since it couldn't find any elements with the word `released`.